### PR TITLE
fix: edge server not recognizing the correct ping response from central server

### DIFF
--- a/services/edge/app/central_server_connection.py
+++ b/services/edge/app/central_server_connection.py
@@ -5,7 +5,7 @@ from .logger import log, logCentralServerHit
 try:
     central_server_ping = get(f"{central_server_address}/ping")
 
-    if central_server_ping.content != "pong!":
+    if central_server_ping.content != b'"pong!"':
         log("Central server unreachable!")
 except:
     log("Central server unreachable!")


### PR DESCRIPTION
This PR adds a fix for the edge server. It used to log `Central server unreachable!` despite it being up and correctly responding on `/ping` endpoint. The problem was with the string that the response was compared to - `Response.content` is a string in bytes. After adjusting the string that the response is compared to everything is working.