### PR TITLE
Services' documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@ docker-compose up
 
 - Wait for the containers to build and run. If everything goes well, logs from both services will fill the terminal.
 
+#### Services' docs
+
+Paths:
+
+- `./services/central`
+- `./services/edge`
+
+contain their respective server's README file that contains the documentation of every implemented function.
+
 #### Performance tests
 
 The `perf_tests/` directory contains `performance_test.py` script. It compares connections with and without edge server by response times. `requirements.txt` file contains the name and version of a dependency needed by the script. After installing it, run the servers and then the script. `test_config.py` contains configuration for the tests. If you make changes to the docker compose file or servers' code, make sure to reflect them in test script config.
@@ -116,6 +125,15 @@ docker-compose up
 ```
 
 - Zaczekaj na zbudowanie i uruchomienie kontenerów. Jeśli wszystko odbędzie się prawidłowo, informacja o uruchomieniu obydwu serwerów powinna pojawić się w terminalu.
+
+#### Dokumentacja usług
+
+Ścieżki:
+
+- `./services/central`
+- `./services/edge`
+
+Zawierają plik README swoich usług. Zawartość tych plików to dokumentacja wszystkich funkcji, jakie zostały zaimplementowane dla danego serwera.
 
 #### Testy wydajności
 

--- a/services/central/README.md
+++ b/services/central/README.md
@@ -1,0 +1,45 @@
+# Central server - docs
+
+Polish version below!
+
+## English
+
+### Config
+
+Contains a config option for attachment directory path.
+
+### Logger
+
+Utilities for logging.
+The module tries attempts to create `logs/` directory(if not present) when imported.
+If it succeeds, the logs will be saved in `<current date in YYYY-mm-dd format>.txt` file. If not - they will only be shown in the console.
+
+#### `log()`
+
+Parameters:
+
+- `message` - a `string` that contains the message to be logged.
+
+Main utility function for logging. Takes a message and adds current time to it, then sends it to the console output and log file if available.
+
+#### `logMemoryHit()`
+
+The utility for logging a memory hit. It automatically counts how many times the server's resources have been accessed.
+
+### Startup
+
+This module takes care of making sure that the attachment directory exists or make a log if it cannot create it.
+
+### Main
+
+The main file of the server. It defines the API endpoints and their logic.
+
+#### `/ping`
+
+A GET endpoint for testing connection. The edge server uses it to check if the central server is available.
+
+#### `/attachment/<attachment name>`
+
+A GET endpoint for retrieving a static file from the server. It can return:
+- A response with code 200 OK and the requested file if present on the server,
+- A response with code 404 Not Found if the file wasn't found on the server.

--- a/services/central/README.md
+++ b/services/central/README.md
@@ -43,3 +43,46 @@ A GET endpoint for testing connection. The edge server uses it to check if the c
 A GET endpoint for retrieving a static file from the server. It can return:
 - A response with code 200 OK and the requested file if present on the server,
 - A response with code 404 Not Found if the file wasn't found on the server.
+
+## Polish
+
+### Config
+
+W tym pliku można skonfigurować nazwę folderu z przechowywanymi plikami.
+
+### Logger
+
+Narzędzia do rejestrowania logów.
+Moduł próbuje stworzyć ścieżkę `logs/` jeśli nie istnieje. Jeśli operacja się powiedzie, logi będą wpisywane do pliku o nazwie `<aktualna data w formacie YYYY-mm-dd>.txt` w tym folderze.
+Jeśli folderu nie da się utworzyć - logi będą jedynie wyświetlane w konsoli.
+
+#### `log()`
+
+Parametry:
+
+- `message` - łańcuch znaków zawierający wiadomość logu.
+
+Główna funkcja do rejestrowania logów. Opatruje wiadomość aktualną godziną, po czym wysyła ją do konsoli, i - jeśli to możliwe - do pliku logów.
+
+#### `logMemoryHit()`
+
+Funkcja do logowania użycia zasobów serwera. Automatycznie zlicza ilość zapytań wysłanych do serwera.
+
+### Startup
+
+Ten moduł upewnia się, że folder z załącznkami istnieje oraz że ewentualny brak możliwości utworzenia go jest zapisany w logach.
+
+### Main
+
+Główny kod serwera. Definiuje endpointy API i ich działanie.
+
+#### `/ping`
+
+Endpoint GET służący do testowania połączenia przez serwer brzegowy.
+
+#### `/attachment/<nazwa załącznika>`
+
+Endpoint GET służący do pobierania plików z serwera. Może zwrócić:
+
+- Odpowiedź z kodem 200 OK i zawartością pliku,
+- Odpowiedź z kodem 404 Not Found jeśli plik nie został znaleziony na serwerze.

--- a/services/central/README.md
+++ b/services/central/README.md
@@ -33,6 +33,7 @@ This module takes care of making sure that the attachment directory exists or ma
 ### Main
 
 The main file of the server. It defines the API endpoints and their logic.
+After running the project the server's Swagger UI is available under `http://localhost:<central server's port>/docs`. It lists all available endpoints and shares an interface to test them.
 
 #### `/ping`
 
@@ -75,6 +76,7 @@ Ten moduł upewnia się, że folder z załącznkami istnieje oraz że ewentualny
 ### Main
 
 Główny kod serwera. Definiuje endpointy API i ich działanie.
+Uruchomiony serwer udostępnia Swagger UI pod adresem `http://localhost:<port serwera centralnego>/docs`. Można przejrzeć w nim listę dostępnych portów oraz je przetestować.
 
 #### `/ping`
 

--- a/services/edge/README.md
+++ b/services/edge/README.md
@@ -82,6 +82,8 @@ A function for retrieving a resource from cache.
 
 A main module that defines all API endpoints.
 
+After running the project the server's Swagger UI is available under `http://localhost:<edge server's port>/docs`. It lists all available endpoints and shares an interface to test them.
+
 #### `/ping`
 
 A GET endpoint useful to check if the server is up.
@@ -174,6 +176,7 @@ Funkcja do pobrania pliku z pamięci podręcznej.
 ### Main
 
 Główny moduł definiujący wszystkie endpointy API.
+Uruchomiony serwer udostępnia Swagger UI pod adresem `http://localhost:<port serwera brzegowego>/docs`. Można przejrzeć w nim listę dostępnych portów oraz je przetestować.
 
 #### `/ping`
 

--- a/services/edge/README.md
+++ b/services/edge/README.md
@@ -92,3 +92,101 @@ A GET endpoint used for fetching the attachment. It first attempts to find it in
 
 - A response with code 200 OK and the file contents,
 - A response with code 404 Not Found.
+
+
+## Polish
+
+### Config
+
+Contains a config option for central server address.
+
+Moduł, w którym można skonfigurować adres do serwera centralnego.
+
+### Logger
+
+Narzędzia do rejestrowania logów.
+Moduł próbuje stworzyć ścieżkę `logs/` jeśli nie istnieje. Jeśli operacja się powiedzie, logi będą wpisywane do pliku o nazwie `<aktualna data w formacie YYYY-mm-dd>.txt` w tym folderze.
+Jeśli folderu nie da się utworzyć - logi będą jedynie wyświetlane w konsoli.
+
+#### `log()`
+
+Parametry:
+
+- `message` - łańcuch znaków zawierający wiadomość logu.
+
+Główna funkcja do rejestrowania logów. Opatruje wiadomość aktualną godziną, po czym wysyła ją do konsoli, i - jeśli to możliwe - do pliku logów.
+
+#### `logCentralServerHit()`
+
+Funkcja służąca do rejestrowania w logach zapytań do serwera głównego. Automatycznie zlicza ilość takich zapytań.
+
+#### `logCacheHit()`
+
+Funkcja służąca do rejestrowania w logach odczytów z pamięci podręcznej. Automatycznie zlicza ilość takich odczytów.
+
+### Central_server_connection
+
+Ten moduł sprawdza łączność z serwerem centralnym i definiuje funkcję służącą do łączenia się z nim.
+
+#### `fetchFromCentralServer()`
+
+Parametry:
+
+- `attachment_name` - nazwa(z rozszerzeniem) pliku do pobrania.
+
+Funkcja służąca do pobierania plików z serwera centralnego. Może zwrócić:
+
+- Zawartość odpowiedzi serwera głównego,
+- `FileNotFoundError`, jeśli serwer zwrócił kod 404.
+
+### Cache
+
+Moduł definiujący pamięć podręczną i funkcje pozwalające na interakcję z nią.
+
+#### `cacheAttachemnt()`
+
+Parametry:
+
+- `attachment` - zawartość pliku do przechowania,
+- `attachment_name` - nazwa(z rozszerzeniem), pod jaką ma być przechowany plik,
+- (opcjonalne) `cache_filesystem` - pamięć, w której plik ma być przechowany. Domyślnie jest to pamięć utworzona przez moduł.
+
+Funkcja, którą można zapisać plik do pamięci podręcznej.
+
+#### `isInCache()`
+
+Parametry:
+
+- `attachment_name` - nazwa(z rozszerzeniem) pliku do wyszukania.
+- (opcjonalne) `cache_filesystem` - pamięć do przeszukania. Domyślnie jest to pamięć utworzona przez moduł.
+
+Funkcja do sprawdzania, czy dany plik znajduje się w pamięci podręcznej.
+
+#### `getFromCache()`
+
+Parametry:
+
+- `attachment_name` - nazwa(z rozszerzeniem) pliku do pobrania z pamięci,\
+- (opcjonalne) `cache_filesystem` - pamięć, z której plik ma być pobrany. Domyślnie jest to pamięć utworzona przez moduł.
+
+Funkcja do pobrania pliku z pamięci podręcznej.
+
+### Main
+
+Główny moduł definiujący wszystkie endpointy API.
+
+#### `/ping`
+
+Endpoint GET służący do sprawdzania łączności.
+
+#### `/attachment/<nazwa załącznika>`
+
+A GET endpoint used for fetching the attachment. It first attempts to find it in the cache and if it's not present, it tries to fetch it from the server. It can return:
+
+- A response with code 200 OK and the file contents,
+- A response with code 404 Not Found.
+
+Endpoint GET służący do pobierania załącznika. Najpierw sprawdzana jest pamięć podręczna; jeśli załącznik się w niej znajduje, jest on z niej pobierany i odsyłany; w przeciwnym wypadku odpytywany jest serwer główny. Możliwe odpowiedzi:
+
+- Z kodem 200 OK i zawartością pliku,
+- Z kodem 404 Not Found.

--- a/services/edge/README.md
+++ b/services/edge/README.md
@@ -1,0 +1,94 @@
+# Edge server - docs
+
+Polish version below!
+
+## English
+
+### Config
+
+Contains a config option for central server address.
+
+### Logger
+
+Utilities for logging.
+The module tries attempts to create `logs/` directory(if not present) when imported.
+If it succeeds, the logs will be saved in `<current date in YYYY-mm-dd format>.txt` file. If not - they will only be shown in the console.
+
+#### `log()`
+
+Parameters:
+
+- `message` - a `string` that contains the message to be logged.
+
+Main utility function for logging. Takes a message and adds current time to it, then sends it to the console output and log file if available.
+
+#### `logCentralServerHit()`
+
+The utility for logging a request to central server. It also counts the total amount of central server requests sent. 
+
+#### `logCacheHit()`
+
+The utility for logging a cache hit. It automatically counts how many times the server's cache have been accessed.
+
+### Central_server_connection
+
+This module checks if the central server is available and defines a utility for fetching files from it.
+
+#### `fetchFromCentralServer()`
+
+Parameters:
+
+- `attachment_name` - name(with an extension) of the file to be fetched.
+
+
+A utility for fetching files from central server. It can return:
+
+- Content from the request sent to the edge server,
+- `FileNotFoundError` if the server returned code 404.
+
+### Cache
+
+A module that defines the edge server's cache and utilites used to interact with it.
+
+#### `cacheAttachemnt()`
+
+Parameters:
+
+- `attachment` - contents of the file to be cached,
+- `attachment_name` - a `string` that contains the attachment name and extension.
+- (Optional) `cache_filesystem` - a cache to save the file in. The default is the cache created by the module.
+
+A functon to save the file to cache.
+
+#### `isInCache()`
+
+Parameters:
+
+- `attachment_name` - a `string` that contains the attachment name and extension.
+- (Optional) `cache_filesystem` - a cache to look through. The default is the cache created by the module.
+
+A function that checks if the file is in the specified cache.
+
+#### `getFromCache()`
+
+Parameters:
+
+- `attachment_name` - a name(with extension) of the file to fetch,
+- `cache_filesystem` - a cache to fetch the file from. The default is the cache created by the module.
+
+A function for retrieving a resource from cache.
+
+### Main
+
+A main module that defines all API endpoints.
+
+#### `/ping`
+
+A GET endpoint useful to check if the server is up.
+
+#### `/attachment/<attachment name>`
+
+A GET endpoint used for fetching the attachment. It first attempts to find it in the cache and if it's not present, it tries to fetch it from the server. It can return:
+
+- A response with code 200 OK and the file contents,
+- A response with code 404 Not Found.

--- a/services/edge/README.md
+++ b/services/edge/README.md
@@ -74,7 +74,7 @@ A function that checks if the file is in the specified cache.
 Parameters:
 
 - `attachment_name` - a name(with extension) of the file to fetch,
-- `cache_filesystem` - a cache to fetch the file from. The default is the cache created by the module.
+- (Optional) `cache_filesystem` - a cache to fetch the file from. The default is the cache created by the module.
 
 A function for retrieving a resource from cache.
 


### PR DESCRIPTION
This PR adds both services documentation in form of READMEs in both `central/` and `edge/` directories. It also adds a mention of these files in the project's main README file.